### PR TITLE
Network and system permission updates

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,11 +14,15 @@ let package = Package(
     ],
     dependencies: [
         // TODO: add logging library
+        // Schwifty Utilities
+        .package(url: "https://github.com/schwiftyos/schwifty-utilities", branch: "main")
     ],
     targets: [
         .target(
             name: "SchwiftyPermissions",
-            dependencies: [],
+            dependencies: [
+                .product(name: "SchwiftyUtilities", package: "schwifty-utilities")
+            ],
             swiftSettings: [
                 .unsafeFlags(["-enable-library-evolution"])
             ]

--- a/Sources/SchwiftyPermissions/PermissionStorage.swift
+++ b/Sources/SchwiftyPermissions/PermissionStorage.swift
@@ -20,9 +20,11 @@ public actor PermissionStorage : Sendable {
     /// Shared permission storage.
     @MainActor public static private(set) var shared:PermissionStorage = PermissionStorage()
 
+    @usableFromInline
     var _system:SystemPermissions!
 
-    /// System-wide permissions that take priority over process and program permissions.
+    /// System-wide permissions that all processes and programs inherit by default.
+    @inlinable
     public private(set) var system : SystemPermissions {
         get {
             if _system == nil { _system = SystemPermissions() }

--- a/Sources/SchwiftyPermissions/PermissionStorage.swift
+++ b/Sources/SchwiftyPermissions/PermissionStorage.swift
@@ -19,19 +19,15 @@ public actor PermissionStorage : Sendable {
     /// Shared permission storage.
     @MainActor public static private(set) var shared:PermissionStorage = PermissionStorage()
 
-    var _system:ProcessPermissions!
+    var _system:SystemPermissions!
 
     /// System-wide permissions that take priority over process and program permissions.
-    public private(set) var system : ProcessPermissions {
+    public private(set) var system : SystemPermissions {
         get {
-            if _system == nil {
-                _system = ProcessPermissions()
-            }
+            if _system == nil { _system = SystemPermissions() }
             return _system
         }
-        set {
-            _system = newValue
-        }
+        set { _system = newValue }
     }
 
     @usableFromInline
@@ -41,7 +37,7 @@ public actor PermissionStorage : Sendable {
     var processes:[Program.ProcessID:ProcessPermissions]
 
     public init(
-        system: ProcessPermissions? = nil
+        system: SystemPermissions? = nil
     ) {
         self._system = system
         programs = [:]

--- a/Sources/SchwiftyPermissions/PermissionStorage.swift
+++ b/Sources/SchwiftyPermissions/PermissionStorage.swift
@@ -9,12 +9,13 @@
 /// 
 /// ## Permissions
 /// 
-/// We support two independent kinds of permissions:
+/// We support 3 independent kinds of permissions:
+///   - system-wide (default)
 ///   - per process
-///   - per program (default)
+///   - per program
 /// 
-/// This allows overriding a running program's permissions without overriding its default permissions,
-/// which unlocks more granular control over a program and its child processes on a case-by-case basis.
+/// This allows overriding a running process's permissions without overriding its inherited permissions,
+/// which unlocks more granular control over processes and programs on a case-by-case basis.
 public actor PermissionStorage : Sendable {
     /// Shared permission storage.
     @MainActor public static private(set) var shared:PermissionStorage = PermissionStorage()

--- a/Sources/SchwiftyPermissions/ProcessPermissions.swift
+++ b/Sources/SchwiftyPermissions/ProcessPermissions.swift
@@ -7,13 +7,13 @@
 
 /// Permissions for a process.
 public final class ProcessPermissions : @unchecked Sendable {
-    var calendar:CalendarPermission! = nil
-    var disk:DiskPermission! = nil
-    var location:LocationPermission! = nil
-    var manipulation:ManipulatePermission! = nil
-    var network:NetworkPermission! = nil
-    var notifications:NotificationPermission! = nil
-    var wallet:WalletPermission! = nil
+    var _calendar:CalendarPermission! = nil
+    var _disk:DiskPermission! = nil
+    var _location:LocationPermission! = nil
+    var _manipulation:ManipulatePermission! = nil
+    var _network:NetworkPermission! = nil
+    var _notifications:NotificationPermission! = nil
+    var _wallet:WalletPermission! = nil
 
     @usableFromInline
     init() {
@@ -26,7 +26,7 @@ extension ProcessPermissions {
     public func request<T: SchwiftyPermission>(
         _ permission: SchwiftyPermissionType,
         for program: Program,
-        reason: String
+        reason: String = "Unspecified"
     ) -> Result<T, PermissionError> {
         let perm:T = getOrLoad(permission, for: program)
         guard program.state.allowsPermissionStatus(perm.status) else {
@@ -49,26 +49,26 @@ extension ProcessPermissions {
     ) -> T {
         switch permission {
         case .calendar:
-            if calendar == nil { calendar = .loadSettings(for: program) }
-            return calendar as! T
+            if _calendar == nil { _calendar = .loadSettings(for: program) }
+            return _calendar as! T
         case .disk:
-            if disk == nil { disk = .loadSettings(for: program) }
-            return disk as! T
+            if _disk == nil { _disk = .loadSettings(for: program) }
+            return _disk as! T
         case .location:
-            if location == nil { location = .loadSettings(for: program) }
-            return location as! T
+            if _location == nil { _location = .loadSettings(for: program) }
+            return _location as! T
         case .manipulation:
-            if manipulation == nil { manipulation = .loadSettings(for: program) }
-            return manipulation as! T
+            if _manipulation == nil { _manipulation = .loadSettings(for: program) }
+            return _manipulation as! T
         case .network:
-            if network == nil { network = .loadSettings(for: program) }
-            return network as! T
+            if _network == nil { _network = .loadSettings(for: program) }
+            return _network as! T
         case .notification:
-            if notifications == nil { notifications = .loadSettings(for: program) }
-            return notifications as! T
+            if _notifications == nil { _notifications = .loadSettings(for: program) }
+            return _notifications as! T
         case .wallet:
-            if wallet == nil { wallet = .loadSettings(for: program) }
-            return wallet as! T
+            if _wallet == nil { _wallet = .loadSettings(for: program) }
+            return _wallet as! T
         }
     }
 }

--- a/Sources/SchwiftyPermissions/ProgramState.swift
+++ b/Sources/SchwiftyPermissions/ProgramState.swift
@@ -12,6 +12,8 @@ import FoundationEssentials
 import Foundation
 #endif
 
+import SchwiftyUtilities
+
 /// Current state of a program.
 public enum ProgramState : Hashable, Sendable {
     case foreground
@@ -32,7 +34,7 @@ extension ProgramState {
         case .uponRequest: return true
 
         #if canImport(FoundationEssentials) || canImport(Foundation)
-        case .temporarilyUntil(let expires): return Date.now < expires
+        case .temporarilyUntil(let expires): return Date.now() < expires
         #endif
 
         @unknown default: return false

--- a/Sources/SchwiftyPermissions/SchwiftyPermission.swift
+++ b/Sources/SchwiftyPermissions/SchwiftyPermission.swift
@@ -15,6 +15,9 @@ public protocol SchwiftyPermission : Sendable {
     /// - Returns: Permission settings for the program (read from disk).
     static func loadSettings(for program: Program) -> Self
 
+    /// - Returns: Permission settings for the system (read from disk).
+    static func loadSystemSettings() -> Self
+
 
     /// Current status of a permission.
     var status : PermissionStatus { get }
@@ -24,6 +27,12 @@ extension SchwiftyPermission {
     @inlinable
     public static func loadSettings(for program: Program) -> Self {
         // TODO: return existing settings for application id
+        return .default
+    }
+
+    @inlinable
+    public static func loadSystemSettings() -> Self {
+        // TODO: return existing settings from disk
         return .default
     }
 }

--- a/Sources/SchwiftyPermissions/SchwiftyPermissionType.swift
+++ b/Sources/SchwiftyPermissions/SchwiftyPermissionType.swift
@@ -5,7 +5,7 @@
 //  Created by Evan Anderson on 2/6/25.
 //
 
-/// List of permissions that control how processes can behave.
+/// List of permissions that control how a system can behave.
 public enum SchwiftyPermissionType : Sendable {
     /*// MARK: general
 

--- a/Sources/SchwiftyPermissions/SystemPermissions.swift
+++ b/Sources/SchwiftyPermissions/SystemPermissions.swift
@@ -1,0 +1,97 @@
+//
+//  SystemPermissions.swift
+//
+//
+//  Created by Evan Anderson on 3/5/25.
+//
+
+public final class SystemPermissions : @unchecked Sendable {
+    var _calendar:CalendarPermission! = nil
+    var _disk:DiskPermission! = nil
+    var _location:LocationPermission! = nil
+    var _manipulation:ManipulatePermission! = nil
+    var _network:NetworkPermission! = nil
+    var _notifications:NotificationPermission! = nil
+    var _wallet:WalletPermission! = nil
+
+    @usableFromInline
+    init() {
+    }
+}
+
+// MARK: Calendar
+extension SystemPermissions {
+    public var calendar : CalendarPermission {
+        get {
+            if _calendar == nil { _calendar = .loadSystemSettings() }
+            return _calendar
+        }
+        set { _calendar = newValue }
+    }
+}
+
+// MARK: Disk
+extension SystemPermissions {
+    public private(set) var disk : DiskPermission {
+        get {
+            if _disk == nil { _disk = .loadSystemSettings() }
+            return _disk
+        }
+        set { _disk = newValue }
+    }
+}
+
+// MARK: Location
+extension SystemPermissions {
+    public private(set) var location : LocationPermission {
+        get {
+            if _location == nil { _location = .loadSystemSettings() }
+            return _location
+        }
+        set { _location = newValue }
+    }
+}
+
+// MARK: Manipulation
+extension SystemPermissions {
+    public private(set) var manipulation : ManipulatePermission {
+        get {
+            if _manipulation == nil { _manipulation = .loadSystemSettings() }
+            return _manipulation
+        }
+        set { _manipulation = newValue }
+    }
+}
+
+// MARK: Network
+extension SystemPermissions {
+    public private(set) var network : NetworkPermission {
+        get {
+            if _network == nil { _network = .loadSystemSettings() }
+            return _network
+        }
+        set { _network = newValue }
+    }
+}
+
+// MARK: Notifications
+extension SystemPermissions {
+    public private(set) var notifications : NotificationPermission {
+        get {
+            if _notifications == nil { _notifications = .loadSystemSettings() }
+            return _notifications
+        }
+        set { _notifications = newValue }
+    }
+}
+
+// MARK: Wallet
+extension SystemPermissions {
+    public private(set) var wallet : WalletPermission {
+        get {
+            if _wallet == nil { _wallet = .loadSystemSettings() }
+            return _wallet
+        }
+        set { _wallet = newValue }
+    }
+}

--- a/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
@@ -11,6 +11,8 @@ import FoundationEssentials
 import Foundation
 #endif
 
+import SchwiftyUtilities
+
 /// Network permissions for a process.
 public struct NetworkPermission : SchwiftyPermission {
     public static let permissionType:SchwiftyPermissionType = .network
@@ -26,8 +28,8 @@ public struct NetworkPermission : SchwiftyPermission {
     /// Number of bytes per second allowed to download/upload for this process.
     public private(set) var bandwidthLimitPerSecond:BandwidthLimit?
 
-    /// Number of bytes this process is allowed to download/upload for a period of time.
-    public private(set) var quota:Quota?
+    /// Network quotas for connection types.
+    public private(set) var quotas:Quotas?
 
     @usableFromInline
     var downloadPermissions:ConnectionType.RawValue
@@ -57,6 +59,17 @@ extension NetworkPermission {
         case hotspot  = 8
         case cellular = 16
         case vpn      = 32
+    }
+}
+// MARK: Quotas
+extension NetworkPermission {
+    public struct Quotas : Sendable {
+        public private(set) var local:NetworkQuota?
+        public private(set) var wired:NetworkQuota?
+        public private(set) var wireless:NetworkQuota?
+        public private(set) var hotspot:NetworkQuota?
+        public private(set) var cellular:NetworkQuota?
+        public private(set) var vpn:NetworkQuota?
     }
 }
 
@@ -95,34 +108,9 @@ extension NetworkPermission {
     /// Network bandwidth limits.
     public struct BandwidthLimit : Sendable {
         /// Number of bytes allowed to download.
-        public private(set) var download:UInt64
+        public private(set) var download:BinaryUnit
 
         /// Number of bytes allowed to upload.
-        public private(set) var upload:UInt64
-    }
-}
-
-// MARK: Quota
-extension NetworkPermission {
-    public struct Quota : Sendable {
-        #if canImport(FoundationEssentials) || canImport(Foundation)
-        /// When tracking of the quota begins.
-        public private(set) var starts:Date
-
-        /// When tracking of the quota ends.
-        public private(set) var ends:Date
-        #endif
-
-        /// Number of bytes allowed to download.
-        public private(set) var download:UInt64
-
-        /// Current number of bytes downloaded.
-        public private(set) var downloaded:UInt64
-
-        /// Number of bytes allowed to upload.
-        public private(set) var upload:UInt64
-
-        /// Current number of bytes uploaded.
-        public private(set) var uploaded:UInt64        
+        public private(set) var upload:BinaryUnit
     }
 }

--- a/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
+++ b/Sources/SchwiftyPermissions/permissions/NetworkPermission.swift
@@ -25,8 +25,8 @@ public struct NetworkPermission : SchwiftyPermission {
     /// URLs the process is not allowed to contact.
     public private(set) var urlBlacklist:Set<String>
 
-    /// Number of bytes per second allowed to download/upload for this process.
-    public private(set) var bandwidthLimitPerSecond:BandwidthLimit?
+    /// Network bandwidth limits for connection types.
+    public private(set) var bandwidthLimits:BandwidthLimits?
 
     /// Network quotas for connection types.
     public private(set) var quotas:Quotas?
@@ -44,7 +44,8 @@ extension NetworkPermission {
         status: .uponRequest,
         urlWhitelist: [],
         urlBlacklist: [],
-        bandwidthLimitPerSecond: nil,
+        bandwidthLimits: nil,
+        quotas: nil,
         downloadPermissions: .max,
         uploadPermissions: .max
     )
@@ -70,6 +71,17 @@ extension NetworkPermission {
         public private(set) var hotspot:NetworkQuota?
         public private(set) var cellular:NetworkQuota?
         public private(set) var vpn:NetworkQuota?
+    }
+}
+// MARK: BandwidthLimits
+extension NetworkPermission {
+    public struct BandwidthLimits : Sendable {
+        public private(set) var local:NetworkBandwidthLimit?
+        public private(set) var wired:NetworkBandwidthLimit?
+        public private(set) var wireless:NetworkBandwidthLimit?
+        public private(set) var hotspot:NetworkBandwidthLimit?
+        public private(set) var cellular:NetworkBandwidthLimit?
+        public private(set) var vpn:NetworkBandwidthLimit?
     }
 }
 
@@ -100,17 +112,5 @@ extension NetworkPermission {
     @inlinable
     public func canUpload(to url: String, over connection: ConnectionType) -> Bool {
         return canUpload(over: connection) && (urlWhitelist.isEmpty || urlWhitelist.contains(url)) && !urlBlacklist.contains(url)
-    }
-}
-
-// MARK: Bandwidth
-extension NetworkPermission {
-    /// Network bandwidth limits.
-    public struct BandwidthLimit : Sendable {
-        /// Number of bytes allowed to download.
-        public private(set) var download:BinaryUnit
-
-        /// Number of bytes allowed to upload.
-        public private(set) var upload:BinaryUnit
     }
 }

--- a/Sources/SchwiftyPermissions/util/NetworkBandwidthLimit.swift
+++ b/Sources/SchwiftyPermissions/util/NetworkBandwidthLimit.swift
@@ -1,0 +1,45 @@
+//
+//  NetworkBandwidthLimit.swift
+//
+//
+//  Created by Evan Anderson on 3/5/25.
+//
+
+import SchwiftyUtilities
+
+/// Network bandwidth limits.
+public struct NetworkBandwidthLimit : Sendable {
+    /// Number of bytes allowed to download.
+    public private(set) var download:BinaryUnit
+
+    /// Number of bytes allowed to upload.
+    public private(set) var upload:BinaryUnit
+}
+
+// MARK: NetworkPermission
+extension NetworkPermission {
+    /// - Returns: The `NetworkBandwidthLimit` for a `ConnectionType`.
+    @inlinable
+    public func bandwidthLimit(for connection: ConnectionType) -> NetworkBandwidthLimit? {
+        switch connection {
+        case .local: return bandwidthLimits?.local
+        case .wired: return bandwidthLimits?.wired
+        case .wireless: return bandwidthLimits?.wireless
+        case .hotspot: return bandwidthLimits?.hotspot
+        case .cellular: return bandwidthLimits?.cellular
+        case .vpn: return bandwidthLimits?.vpn
+        @unknown default: return nil
+        }
+    }
+
+    /// - Returns: The active `NetworkBandwidthLimit` for a `ConnectionType`.
+    /// Defaults to the system network bandwidth limit for the connection type, if configured.
+    @inlinable
+    public func activeBandwidthLimit(for connection: ConnectionType) async -> NetworkBandwidthLimit? {
+        var limit = bandwidthLimit(for: connection)
+        if limit == nil {
+            limit = await PermissionStorage.shared.system.network.bandwidthLimit(for: connection)
+        }
+        return limit
+    }
+}

--- a/Sources/SchwiftyPermissions/util/NetworkQuota.swift
+++ b/Sources/SchwiftyPermissions/util/NetworkQuota.swift
@@ -64,7 +64,7 @@ extension NetworkPermission {
         #if canImport(FoundationEssentials) || canImport(Foundation)
         if let quota {
             let now:Date = Date.now()
-            guard now >= quota.starts && now <= quota.ends else { return nil }
+            guard now >= quota.starts && now < quota.ends else { return nil }
         }
         #endif
         return quota

--- a/Sources/SchwiftyPermissions/util/NetworkQuota.swift
+++ b/Sources/SchwiftyPermissions/util/NetworkQuota.swift
@@ -1,0 +1,86 @@
+//
+//  NetworkQuota.swift
+//
+//
+//  Created by Evan Anderson on 3/5/25.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
+import Foundation
+#endif
+
+import SchwiftyUtilities
+
+// MARK: NetworkQuota
+/// Limits the amount of bytes a process can download/upload within a time frame.
+public struct NetworkQuota : Sendable {
+    #if canImport(FoundationEssentials) || canImport(Foundation)
+    /// When tracking of the quota begins.
+    public private(set) var starts:Date
+
+    /// When tracking of the quota ends.
+    public private(set) var ends:Date
+    #endif
+
+    /// Number of bytes allowed to download.
+    public private(set) var download:UInt64
+
+    /// Current number of bytes downloaded.
+    public private(set) var downloaded:UInt64
+
+    /// Number of bytes allowed to upload.
+    public private(set) var upload:UInt64
+
+    /// Current number of bytes uploaded.
+    public private(set) var uploaded:UInt64        
+}
+
+// MARK: NetworkPermission
+extension NetworkPermission {
+    /// - Returns: The `NetworkQuota` for a `ConnectionType`.
+    @inlinable
+    public func quota(for connection: ConnectionType) async -> NetworkQuota? {
+        switch connection {
+        case .local: return quotas?.local
+        case .wired: return quotas?.wired
+        case .wireless: return quotas?.wireless
+        case .hotspot: return quotas?.hotspot
+        case .cellular: return quotas?.cellular
+        case .vpn: return quotas?.vpn
+        @unknown default: return nil
+        }
+    }
+
+    /// - Returns: The active `NetworkQuota` for a `connectionType`.
+    /// Defaults to the system network quota for the connection type, if configured.
+    @inlinable
+    public func activeQuota(for connection: ConnectionType) async -> NetworkQuota? {
+        var quota = await quota(for: connection)
+        if quota == nil {
+            quota = await PermissionStorage.shared.system.network.quota(for: connection)
+        }
+        #if canImport(FoundationEssentials) || canImport(Foundation)
+        if let quota {
+            let now:Date = Date.now()
+            guard now >= quota.starts && now <= quota.ends else { return nil }
+        }
+        #endif
+        return quota
+    }
+    
+    /// - Returns: Whether or not a number of bytes can be downloaded over a connection type, taking into account the active quota.
+    @inlinable
+    public func canDownload(bytes: UInt64, over connection: ConnectionType) async -> Bool {
+        guard let quota = await activeQuota(for: connection) else { return true }
+        return quota.downloaded + bytes <= quota.download
+    }
+
+    /// - Returns: Whether or not a number of bytes can be uploaded over a connection type, taking into account the active quota.
+    @inlinable
+    public func canUpload(bytes: UInt64, over connection: ConnectionType) async -> Bool {
+        guard let quota = await activeQuota(for: connection) else { return true }
+        return quota.uploaded + bytes <= quota.upload
+    }
+}

--- a/Sources/SchwiftyPermissions/util/NetworkQuota.swift
+++ b/Sources/SchwiftyPermissions/util/NetworkQuota.swift
@@ -41,7 +41,7 @@ public struct NetworkQuota : Sendable {
 extension NetworkPermission {
     /// - Returns: The `NetworkQuota` for a `ConnectionType`.
     @inlinable
-    public func quota(for connection: ConnectionType) async -> NetworkQuota? {
+    public func quota(for connection: ConnectionType) -> NetworkQuota? {
         switch connection {
         case .local: return quotas?.local
         case .wired: return quotas?.wired
@@ -53,11 +53,11 @@ extension NetworkPermission {
         }
     }
 
-    /// - Returns: The active `NetworkQuota` for a `connectionType`.
+    /// - Returns: The active `NetworkQuota` for a `ConnectionType`.
     /// Defaults to the system network quota for the connection type, if configured.
     @inlinable
     public func activeQuota(for connection: ConnectionType) async -> NetworkQuota? {
-        var quota = await quota(for: connection)
+        var quota = quota(for: connection)
         if quota == nil {
             quota = await PermissionStorage.shared.system.network.quota(for: connection)
         }


### PR DESCRIPTION
- adds `NetworkBandwidthLimit` struct and relevant logic
- adds `NetworkQuota` struct and relevant logic
- adds `SystemPermissions` struct to better handle system-wide permissions
- adds static function `loadSystemSettings` to `SchwiftyPermission`
- introduce `system` variable to `PermissionStorage` to support system-wide permissions
- remove some unambiguous type annotations
- prefixed some internal variables with an underscore
- adopt `SchwiftyUtilities` dependency