### PR TITLE
Task: Globalize the review of all hidden files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,8 @@ CODEOWNERS @schwiftyos/technical-managers
 
   # Require review of hidden files
 .** @schwiftyos/technical-managers
+**/.* @schwiftyos/technical-managers
+**/.** @schwiftyos/technical-managers
 
   # Require review of Build Setting manipulation
 Package.swift @schwiftyos/technical-managers


### PR DESCRIPTION
Files which were not in the root directory were not always claimed when hidden with a leading `.` 