### PR TITLE
Task: Add `6.1` to testing versions

### DIFF
--- a/.github/workflows/swift_package_test.yaml
+++ b/.github/workflows/swift_package_test.yaml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ['5.8', '5.9', '5.10', '6.0', 'nightly-main', 'nightly-6.1']
+        swift_version: ['5.8', '5.9', '5.10', '6.0', '6.1', 'nightly-main', 'nightly-6.1']
         os_version: ${{ fromJson(inputs.linux_os_versions) }}
         exclude: ${{ fromJson(inputs.linux_exclude_swift_versions) }}
     container:


### PR DESCRIPTION
Swift 6.1 has been released. This is to check the stability of updating the approved build version